### PR TITLE
Fix deprecated constructor names in Phreeze Builder

### DIFF
--- a/builder/libs/App/AppConfig.php
+++ b/builder/libs/App/AppConfig.php
@@ -20,7 +20,7 @@ class AppConfig
 	 * Constructor.
 	 * @param string path to config file
 	 */
-	function AppConfig($configFilePath)
+	function __construct($configFilePath)
 	{
 		$this->configFilePath = $configFilePath;
 	}

--- a/builder/libs/App/AppParameter.php
+++ b/builder/libs/App/AppParameter.php
@@ -16,7 +16,7 @@ class AppParameter
 	* @param string $name	 Parameter name.
 	* @param string $value	Parameter value.
 	*/
-	function AppParameter($name=null, $value=null)
+	function __construct($name=null, $value=null)
 	{
 	  $this->name = $name;
 	  $this->value = $value;

--- a/builder/libs/App/TemplateFile.php
+++ b/builder/libs/App/TemplateFile.php
@@ -5,7 +5,7 @@ class TemplateFile
 	public $destination;
 	public $single;
 
-	public function TemplateFile($row = "")
+	public function __construct($row = "")
 	{
 		$cols = explode("\t",trim($row));
 		if (count($cols) != 3) throw new Exception("Invalid row Paramter: " . $row);


### PR DESCRIPTION
This PR intends to make Phreeze compliant with future PHP versions by not using class names as constructors.
It will also avoid getting an Deprecated error on PHP 7+

Fix issue #239 
